### PR TITLE
Adding compile guards

### DIFF
--- a/options/data_flash.cpp
+++ b/options/data_flash.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#ifdef DEVICE_SPI
+
 #include "DataFlashBlockDevice.h"
 
 DataFlashBlockDevice* _storage_selector_DATA_FLASH() {
@@ -23,3 +25,5 @@ DataFlashBlockDevice* _storage_selector_DATA_FLASH() {
                                    MBED_CONF_DATAFLASH_SPI_CS);
     return &bd;
 }
+
+#endif //DEVICE_SPI

--- a/options/data_flash.h
+++ b/options/data_flash.h
@@ -17,8 +17,13 @@
 #ifndef STORAGE_SELECTOR_DATAFLASH_H
 #define STORAGE_SELECTOR_DATAFLASH_H
 
+#ifdef DEVICE_SPI
+
 #include "DataFlashBlockDevice.h"
 
+
 DataFlashBlockDevice* _storage_selector_DATA_FLASH();
+
+#endif //DEVICE_SPI
 
 #endif //STORAGE_SELECTOR_DATAFLASH_H

--- a/options/internal_flash.cpp
+++ b/options/internal_flash.cpp
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifdef DEVICE_FLASH
 
 #include "FlashIAPBlockDevice.h"
 
@@ -21,3 +22,5 @@ FlashIAPBlockDevice* _storage_selector_INTERNAL_FLASH() {
                                   MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE);
     return &bd;
 }
+
+#endif //DEVICE_FLASH

--- a/options/internal_flash.h
+++ b/options/internal_flash.h
@@ -17,8 +17,12 @@
 #ifndef STORAGE_SELECTOR_INTERNAL_FLASH_H
 #define STORAGE_SELECTOR_INTERNAL_FLASH_H
 
+#ifdef DEVICE_FLASH
+
 #include "FlashIAPBlockDevice.h"
 
 FlashIAPBlockDevice* _storage_selector_INTERNAL_FLASH();
+
+#endif //DEVICE_FLASH
 
 #endif //STORAGE_SELECTOR_INTERNAL_FLASH_H

--- a/options/sd_card.cpp
+++ b/options/sd_card.cpp
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+#ifdef DEVICE_SPI
+
 #include "SDBlockDevice.h"
 
 SDBlockDevice* _storage_selector_SD_CARD() {
     static SDBlockDevice bd(MBED_CONF_SD_SPI_MOSI, MBED_CONF_SD_SPI_MISO, MBED_CONF_SD_SPI_CLK, MBED_CONF_SD_SPI_CS);
     return &bd;
 }
+
+#endif //DEVICE_SPI

--- a/options/sd_card.h
+++ b/options/sd_card.h
@@ -17,8 +17,12 @@
 #ifndef _SD_CARD_H_
 #define _SD_CARD_H_
 
+#ifdef DEVICE_SPI
+
 #include "SDBlockDevice.h"
 
 SDBlockDevice* _storage_selector_SD_CARD();
+
+#endif //DEVICE_SPI
 
 #endif //_SD_CARD_H_

--- a/options/spi_flash.cpp
+++ b/options/spi_flash.cpp
@@ -14,9 +14,13 @@
  * limitations under the License.
  */
 
+#ifdef DEVICE_SPI
+
 #include "SPIFBlockDevice.h"
 
 SPIFBlockDevice* _storage_selector_SPI_FLASH() {
     static SPIFBlockDevice bd(MBED_CONF_SPIF_DRIVER_SPI_MOSI, MBED_CONF_SPIF_DRIVER_SPI_MISO, MBED_CONF_SPIF_DRIVER_SPI_CLK, MBED_CONF_SPIF_DRIVER_SPI_CS);
     return &bd;
 }
+
+#endif //DEVICE_SPI

--- a/options/spi_flash.h
+++ b/options/spi_flash.h
@@ -17,8 +17,12 @@
 #ifndef SPI_FLASH_H
 #define SPI_FLASH_H
 
+#ifdef DEVICE_SPI
+
 #include "SPIFBlockDevice.h"
 
 SPIFBlockDevice* _storage_selector_SPI_FLASH();
+
+#endif //DEVICE_SPI
 
 #endif //_SPI_FLASH_


### PR DESCRIPTION
If a device doesn't support a certain type of interface, and therefore doesn't get to define the driver (due to `DEVICE_*` macros not being present), the included options will be using an undeclared type.

We need to add the same `#ifdef` guards here as well.