### PR TITLE
Multiple filesystems

### DIFF
--- a/.circleci/main.cpp
+++ b/.circleci/main.cpp
@@ -13,8 +13,8 @@ int main() {
 
     // Multiple filesystem example (partitions)
     printf("Fs warnings may show here...\r\n");
-    FileSystem *fs1 = filesystem_selector("s1", &slice1, 0);
-    FileSystem *fs2 = filesystem_selector("s2", &slice2, 1);
+    FileSystem *fs1 = filesystem_selector("s1", &slice1, 1);
+    FileSystem *fs2 = filesystem_selector("s2", &slice2, 2);
 
     printf("\r\nReformatting...\r\n");
     fs1->reformat();

--- a/.circleci/main.cpp
+++ b/.circleci/main.cpp
@@ -13,8 +13,8 @@ int main() {
 
     // Multiple filesystem example (partitions)
     printf("Fs warnings may show here...\r\n");
-    FileSystem *fs1 = filesystem_selector(&slice1, "s1", 0);
-    FileSystem *fs2 = filesystem_selector(&slice2, "s2", 1);
+    FileSystem *fs1 = filesystem_selector("s1", &slice1, 0);
+    FileSystem *fs2 = filesystem_selector("s2", &slice2, 1);
 
     printf("\r\nReformatting...\r\n");
     fs1->reformat();

--- a/.circleci/main.cpp
+++ b/.circleci/main.cpp
@@ -2,13 +2,29 @@
 #include "storage-selector.h"
 
 int main() {
-    // Create both the filesystem and the block device
-    FileSystem *fs = filesystem_selector();
-
+    printf("Starting...\r\n");
     // Retrieve just the block device and get erase size
     BlockDevice *bd = storage_selector();
+    bd->init();
     volatile bd_size_t erase_size = bd->get_erase_size();
 
+    SlicingBlockDevice slice1(bd, 0*512, 32*512);
+    SlicingBlockDevice slice2(bd, 32*512, 64*512);
+
+    // Multiple filesystem example (partitions)
+    printf("Fs warnings may show here...\r\n");
+    FileSystem *fs1 = filesystem_selector(&slice1, "s1", 0);
+    FileSystem *fs2 = filesystem_selector(&slice2, "s2", 1);
+
+    printf("\r\nReformatting...\r\n");
+    fs1->reformat();
+    fs2->reformat();
+
     // Unmount fs
-    fs->unmount();
+    fs1->unmount();
+    fs2->unmount();
+
+    fs1->mount(&slice1);
+    fs2->mount(&slice2);
+    printf("Completed!\r\n");
 }

--- a/.circleci/mbed_app.json
+++ b/.circleci/mbed_app.json
@@ -3,7 +3,8 @@
         "*": {
             "storage-selector.storage": "SD_CARD",
             "storage-selector.mount-point": "\"fs\"",
-            "storage-selector.filesystem": "FAT"
+            "storage-selector.filesystem": "FAT",
+            "storage-selector.filesystem-instances": 2
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ MBRBlockDevice part1(bd, 1);
 MBRBlockDevice part2(bd, 2);
 
 // Mount the filesystems
-FileSystem *fs1 = filesystem_selector("fs1", &part1, 0);
-FileSystem *fs2 = filesystem_selector("fs2", &part2, 1);
+FileSystem *fs1 = filesystem_selector("fs1", &part1, 1);
+FileSystem *fs2 = filesystem_selector("fs2", &part2, 2);
 ```
 
 ## Using the filesystem

--- a/README.md
+++ b/README.md
@@ -73,6 +73,38 @@ In your application's `mbed_app.json`, add the following lines:
 
 Where `NUCLEO_F429ZI` should be replaced by your target, `FAT` should be replaced by the filesystem option, and `mount-point` should be replaced with the filesystem mounting point. Note the escaped double quotes around the mounting point. You only need to configure a filesystem if you intend to use one.
 
+## Multiple filesystems/partitions
+
+You need to configure an addition config parameter to use multiple filesystems/partitions:
+
+```
+{
+    "target_overrides": {
+        "NUCLEO_F429ZI": {
+            "storage-selector.filesystem-instances": 2
+        }
+    }
+}
+```
+
+The following is an example of using the `MBRBlockDevice` to use multiple partitions.
+
+```c++
+// Get the block device
+BlockDevice *bd = storage_selector();
+bd->init();
+
+// Create and initialize partitions
+MBRBlockDevice::partition(bd , 1, 0x83, 0, 512*1024);
+MBRBlockDevice::partition(bd , 2, 0x83, 512*1024, 1024*1024);
+MBRBlockDevice part1(bd, 1);
+MBRBlockDevice part2(bd, 2);
+
+// Mount the filesystems
+FileSystem *fs1 = filesystem_selector("fs1", &part1, 0);
+FileSystem *fs2 = filesystem_selector("fs2", &part2, 1);
+```
+
 ## Using the filesystem
 
 In your application, you can instantiate the filesystem like this:

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -9,9 +9,13 @@
             "help": "Options are FAT and LITTLE",
             "required": false
         },
+        "filesystem-instances": {
+            "help": "Number of available filesystems (Default: 1)",
+            "value": 1
+        },
         "mount-point": {
             "help": "Where to mount the filesystem",
-            "required": false
+            "value": "NULL"
         },
         "heap_size": {
             "help": "Size to use for HEAP storage option",

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -10,7 +10,7 @@
             "required": false
         },
         "filesystem-instances": {
-            "help": "Number of available filesystems (Default: 1)",
+            "help": "Number of available filesystems/partitions (Default: 1)",
             "value": 1
         },
         "mount-point": {

--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd) {
-    static FATFileSystem fs(mount, bd);
-    return &fs;
+FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+    static FATFileSystem fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
+    return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "FATFileSystem.h"
 
 FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    static FATFileSystem fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
+    static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/fat_filesystem.h
+++ b/options/fat_filesystem.h
@@ -20,6 +20,6 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd);
+FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num);
 
 #endif //STORAGE_SELECTOR_FAT_FILESYSTEM_H

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "LittleFileSystem.h"
 
-LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd) {
-    static LittleFileSystem fs(mount, bd);
-    return &fs;
+LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+    static LittleFileSystem fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
+    return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "LittleFileSystem.h"
 
 LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    static LittleFileSystem fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
+    static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }

--- a/options/little_filesystem.h
+++ b/options/little_filesystem.h
@@ -20,6 +20,6 @@
 #include "BlockDevice.h"
 #include "LittleFileSystem.h"
 
-LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd);
+LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num);
 
 #endif //STORAGE_SELECTOR_LITTLE_FILESYSTEM_H

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -40,7 +40,7 @@ BlockDevice* storage_selector() {
 #ifdef MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
 bool _filesystem_initialized[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES];
 
-FileSystem* filesystem_selector(BlockDevice* bd, const char* mount, unsigned int instance_number = 0) {
+FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int instance_number = 0) {
     // Ensure the requested filesystem instance is inside the declared range
     MBED_ASSERT(instance_number < MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES);
     // Ensure the filesystem instance hasn't already been initialized
@@ -50,7 +50,7 @@ FileSystem* filesystem_selector(BlockDevice* bd, const char* mount, unsigned int
 }
 
 FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT) {
-    return filesystem_selector(storage_selector(), mount, 0);
+    return filesystem_selector(mount, storage_selector(), 0);
 }
 
 #endif //MBED_CONF_STORAGE_SELECTOR_FILESYSTEM

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -38,14 +38,21 @@ BlockDevice* storage_selector() {
 }
 
 #ifdef MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
-FileSystem* filesystem_selector(BlockDevice* bd) {
-    return _FILESYSTEM_SELECTOR(MBED_CONF_STORAGE_SELECTOR_FILESYSTEM, MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT, bd);
+bool _filesystem_initialized[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES];
+
+FileSystem* filesystem_selector(BlockDevice* bd, const char* mount, unsigned int instance_number = 0) {
+    // Ensure the requested filesystem instance is inside the declared range
+    MBED_ASSERT(instance_number < MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES);
+    // Ensure the filesystem instance hasn't already been initialized
+    MBED_ASSERT(!_filesystem_initialized[instance_number]);
+    _filesystem_initialized[instance_number] = true;
+    return _FILESYSTEM_SELECTOR(MBED_CONF_STORAGE_SELECTOR_FILESYSTEM, mount, bd, instance_number);
 }
 
-FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT,
-                                BlockDevice* bd = storage_selector()) {
-    return _FILESYSTEM_SELECTOR(MBED_CONF_STORAGE_SELECTOR_FILESYSTEM, mount, bd);
+FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT) {
+    return filesystem_selector(storage_selector(), mount, 0);
 }
-#endif
+
+#endif //MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
 
 #endif //_STORAGE_SELECTOR_H_

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -40,7 +40,13 @@ BlockDevice* storage_selector() {
 #ifdef MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
 bool _filesystem_initialized[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES];
 
-FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int instance_number = 0) {
+FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int instance_number = 1) {
+    // Filesystem numbering starts at 1, not 0
+    // This is meant to mirror the partition numbering present in MBRBlockDevice
+    MBED_ASSERT(instance_number != 0);
+
+    // Move to zero index here for internal operations
+    instance_number--;
     // Ensure the requested filesystem instance is inside the declared range
     MBED_ASSERT(instance_number < MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES);
     // Ensure the filesystem instance hasn't already been initialized
@@ -50,7 +56,7 @@ FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int
 }
 
 FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT) {
-    return filesystem_selector(mount, storage_selector(), 0);
+    return filesystem_selector(mount, storage_selector(), 1);
 }
 
 #endif //MBED_CONF_STORAGE_SELECTOR_FILESYSTEM


### PR DESCRIPTION
This is a proposal to fix #17.

~~I will be adding docs to this shortly, but I wanted to get this up so folks can start reviewing it.~~ Readme updated!

This adds an additional `filesystem-instances` config option, allowing you to use multiple partitions.

The `filesystem_selector` API has also added a few options. You can now call the API in the following permutations:

```c++
// Use the default BD and mount point, always returns same FS pointer
FileSystem *fs = filesystem_selector();

// Use the default BD, but specify the mount point, always returns same FS pointer
FileSystem *fs = filesystem_selector("fs");

// Choose BD and mountpoint, always returns same FS pointer
FileSystem *fs = filesystem_selector(storage_selector(), "fs");

// Multipartition example
BlockDevice *bd = storage_selector();
MBRBlockDevice::partition(bd , PRIMARY_PARTITION_NUMBER, 0x83, PRIMARY_PARTITION_START, PRIMARY_PARTITION_START + PRIMARY_PARTITION_SIZE);
MBRBlockDevice::partition(bd , SECONDARY_PARTITION_NUMBER, 0x83, SECONDARY_PARTITION_START, SECONDARY_PARTITION_START + SECONDARY_PARTITION_SIZE);
MBRBlockDevice part1(bd, 1);
MBRBlockDevice part2(bd, 2);
FileSystem *fs1 = filesystem_selector("sd1", &part1, 0);
FileSystem *fs2 = filesystem_selector("sd2", &part2, 1);

```