### PR TITLE
Remove littlefs lib since it is now merged into Mbed OS

### DIFF
--- a/littlefs.lib
+++ b/littlefs.lib
@@ -1,1 +1,0 @@
-https://github.com/ARMmbed/mbed-littlefs/#72fab82453c60668a7b9b2c0b17f3482398d926a


### PR DESCRIPTION
Fixes #19 

This will actually fail CI tests at the moment since Littlefs hasn't been in a released version of Mbed OS. However the branch should still be ok to use with the master branch of Mbed OS.