### PR TITLE
Bring in updated spif-driver

### DIFF
--- a/spif-driver.lib
+++ b/spif-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/spif-driver/#780bef007640b35bd5bf5d40f318511278676e05
+https://github.com/ARMmbed/spif-driver/#e5e6616914a23fb11a5ae8b5c9cbfb8a600c64b2


### PR DESCRIPTION
NRF52840 SPIF pin definitions and a K82F pin number fix were added.

Filesystem example update PR as reference: https://github.com/ARMmbed/mbed-os-example-filesystem/pull/19