### PR TITLE
Fix unaligned access on filesystem object

### DIFF
--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "FATFileSystem.h"
 
 FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
+    MBED_ALIGN(4) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "LittleFileSystem.h"
 
 LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
+    MBED_ALIGN(4) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }


### PR DESCRIPTION
The memory allocated to store the
objects is a char array which is
not garanteed to be 4-byte aligned.

Which means when you use this memory
to create new objects, the objects can
fall on unaligned addresses. Then
when you try to access the members
in this object, you end up with an
unaligned memory access fault.

This patch uses MBED_ALIGN directive
to force alignment