### PR TITLE
Alignment must conform to the ARM ABI

### DIFF
--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "FATFileSystem.h"
 
 FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    MBED_ALIGN(4) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
+    MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -18,6 +18,6 @@
 #include "LittleFileSystem.h"
 
 LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
-    MBED_ALIGN(4) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
+    MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }


### PR DESCRIPTION
In the absence of the C++11 `alignof` or `alignas` operators, or some pretty gnarly C++ TMP, this is probably the best option.

Fixes #24