### PR TITLE
Reverting CI pip to v9 due to mbed-cli issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,9 @@ jobs:
         steps:
             - checkout
             - run:
+                name: Revert pip to version 9.0.3
+                command: pip install pip==9.0.3
+            - run:
                 name: Install Mbed CLI
                 command: pip install mbed-cli
             - run:


### PR DESCRIPTION
This commit can be reverted pending: https://github.com/ARMmbed/mbed-cli/pull/661