### PR TITLE
Updating sd driver to f1bb57ae79bde0743dba046415e86b3201fd8fcf

### DIFF
--- a/sd-driver.lib
+++ b/sd-driver.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/sd-driver/#48bdc8821bbfd9689a647204fdb256723ce46c04
+https://github.com/ARMmbed/sd-driver/#f1bb57ae79bde0743dba046415e86b3201fd8fcf


### PR DESCRIPTION
This commit is required for NUCLEO F411RE to work with MbedCloudClient.