### PR TITLE
Using mbed.h instead of direct include of blockdevice

### DIFF
--- a/.circleci/sstest.h
+++ b/.circleci/sstest.h
@@ -1,3 +1,3 @@
-#include "BlockDevice.h"
+#include "mbed.h"
 
 BlockDevice* sstest_indirection();

--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "BlockDevice.h"
+#include "mbed.h"
 #include "FATFileSystem.h"
 
 FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {

--- a/options/fat_filesystem.h
+++ b/options/fat_filesystem.h
@@ -17,7 +17,7 @@
 #ifndef STORAGE_SELECTOR_FAT_FILESYSTEM_H
 #define STORAGE_SELECTOR_FAT_FILESYSTEM_H
 
-#include "BlockDevice.h"
+#include "mbed.h"
 #include "FATFileSystem.h"
 
 FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num);

--- a/options/heap.cpp
+++ b/options/heap.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "HeapBlockDevice.h"
+#include "mbed.h"
 
 HeapBlockDevice* _storage_selector_HEAP() {
     static HeapBlockDevice bd(MBED_CONF_STORAGE_SELECTOR_HEAP_SIZE);

--- a/options/heap.h
+++ b/options/heap.h
@@ -17,7 +17,7 @@
 #ifndef _HEAP_H_
 #define _HEAP_H_
 
-#include "HeapBlockDevice.h"
+#include "mbed.h"
 
 HeapBlockDevice* _storage_selector_HEAP();
 

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "BlockDevice.h"
+#include "mbed.h"
 #include "LittleFileSystem.h"
 
 LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {

--- a/options/little_filesystem.h
+++ b/options/little_filesystem.h
@@ -17,7 +17,7 @@
 #ifndef STORAGE_SELECTOR_LITTLE_FILESYSTEM_H
 #define STORAGE_SELECTOR_LITTLE_FILESYSTEM_H
 
-#include "BlockDevice.h"
+#include "mbed.h"
 #include "LittleFileSystem.h"
 
 LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num);

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -17,7 +17,7 @@
 #ifndef _STORAGE_SELECTOR_H_
 #define _STORAGE_SELECTOR_H_
 
-#include "BlockDevice.h"
+#include "mbed.h"
 #include "filesystem/FileSystem.h"
 
 BlockDevice* storage_selector();


### PR DESCRIPTION
`BlockDevice` was brought into the `mbed` namespace with https://github.com/ARMmbed/mbed-os/pull/7663.

This breaks the current "direct include" of `BlockDevice.h` that is currently in use. This PR moves to including `mbed.h` so the namespace is used correctly. This should be backwards compatible with previous releases of Mbed OS as well.