### PR TITLE
Blockdevice moved to mbed namespace in mbed-os master

### DIFF
--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+FATFileSystem* _filesystem_selector_FAT(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num) {
     MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/fat_filesystem.h
+++ b/options/fat_filesystem.h
@@ -20,6 +20,6 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num);
+FATFileSystem* _filesystem_selector_FAT(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num);
 
 #endif //STORAGE_SELECTOR_FAT_FILESYSTEM_H

--- a/options/heap.cpp
+++ b/options/heap.cpp
@@ -16,7 +16,7 @@
 
 #include "HeapBlockDevice.h"
 
-HeapBlockDevice* _storage_selector_HEAP() {
-    static HeapBlockDevice bd(MBED_CONF_STORAGE_SELECTOR_HEAP_SIZE);
+mbed::HeapBlockDevice* _storage_selector_HEAP() {
+    static mbed::HeapBlockDevice bd(MBED_CONF_STORAGE_SELECTOR_HEAP_SIZE);
     return &bd;
 }

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "LittleFileSystem.h"
 
-LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num) {
     MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -20,11 +20,11 @@
 #include "BlockDevice.h"
 #include "filesystem/FileSystem.h"
 
-BlockDevice* storage_selector();
+mbed::BlockDevice* storage_selector();
 
 #ifdef MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
 
-mbed::FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int instance_number = 1);
+mbed::FileSystem* filesystem_selector(const char* mount, mbed::BlockDevice* bd, unsigned int instance_number = 1);
 
 mbed::FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT);
 


### PR DESCRIPTION
BlockDevice was moved under mbed namespace in mbed-os PR #7663 (commit 509869dc81843bee710c65725924f7d13bfe7cbe).

Made changes accordingly.