### PR TITLE
Using mbed namespace for block devices

### DIFF
--- a/options/fat_filesystem.cpp
+++ b/options/fat_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+FATFileSystem* _filesystem_selector_FAT(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num) {
     MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(FATFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(FATFileSystem)])) FATFileSystem(mount, bd);
 }

--- a/options/fat_filesystem.h
+++ b/options/fat_filesystem.h
@@ -20,6 +20,6 @@
 #include "BlockDevice.h"
 #include "FATFileSystem.h"
 
-FATFileSystem* _filesystem_selector_FAT(const char* mount, BlockDevice* bd, unsigned int instance_num);
+FATFileSystem* _filesystem_selector_FAT(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num);
 
 #endif //STORAGE_SELECTOR_FAT_FILESYSTEM_H

--- a/options/heap.cpp
+++ b/options/heap.cpp
@@ -16,7 +16,7 @@
 
 #include "HeapBlockDevice.h"
 
-HeapBlockDevice* _storage_selector_HEAP() {
-    static HeapBlockDevice bd(MBED_CONF_STORAGE_SELECTOR_HEAP_SIZE);
+mbed::HeapBlockDevice* _storage_selector_HEAP() {
+    static mbed::HeapBlockDevice bd(MBED_CONF_STORAGE_SELECTOR_HEAP_SIZE);
     return &bd;
 }

--- a/options/heap.h
+++ b/options/heap.h
@@ -19,6 +19,6 @@
 
 #include "HeapBlockDevice.h"
 
-HeapBlockDevice* _storage_selector_HEAP();
+mbed::HeapBlockDevice* _storage_selector_HEAP();
 
 #endif //_HEAP_H_

--- a/options/little_filesystem.cpp
+++ b/options/little_filesystem.cpp
@@ -17,7 +17,7 @@
 #include "BlockDevice.h"
 #include "LittleFileSystem.h"
 
-LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num) {
+LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num) {
     MBED_ALIGN(2*sizeof(uintptr_t)) static char fs_instances[MBED_CONF_STORAGE_SELECTOR_FILESYSTEM_INSTANCES * sizeof(LittleFileSystem)];
     return new(&(fs_instances[instance_num * sizeof(LittleFileSystem)])) LittleFileSystem(mount, bd);
 }

--- a/options/little_filesystem.h
+++ b/options/little_filesystem.h
@@ -20,6 +20,6 @@
 #include "BlockDevice.h"
 #include "LittleFileSystem.h"
 
-LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, BlockDevice* bd, unsigned int instance_num);
+LittleFileSystem* _filesystem_selector_LITTLE(const char* mount, mbed::BlockDevice* bd, unsigned int instance_num);
 
 #endif //STORAGE_SELECTOR_LITTLE_FILESYSTEM_H

--- a/storage-selector.cpp
+++ b/storage-selector.cpp
@@ -22,6 +22,8 @@
 #include "options/fat_filesystem.h"
 #include "options/little_filesystem.h"
 
+using mbed::BlockDevice;
+
 // These two macros are a bit of magic that concatinate the symbol and
 // function prefix to create a valid function name
 #define _STORAGE_SELECTOR_concat(dev) _storage_selector_##dev()

--- a/storage-selector.h
+++ b/storage-selector.h
@@ -20,11 +20,11 @@
 #include "BlockDevice.h"
 #include "filesystem/FileSystem.h"
 
-BlockDevice* storage_selector();
+mbed::BlockDevice* storage_selector();
 
 #ifdef MBED_CONF_STORAGE_SELECTOR_FILESYSTEM
 
-mbed::FileSystem* filesystem_selector(const char* mount, BlockDevice* bd, unsigned int instance_number = 1);
+mbed::FileSystem* filesystem_selector(const char* mount, mbed::BlockDevice* bd, unsigned int instance_number = 1);
 
 mbed::FileSystem* filesystem_selector(const char* mount = MBED_CONF_STORAGE_SELECTOR_MOUNT_POINT);
 


### PR DESCRIPTION
This is a follow up to #39 and #38. This should be the least intrusive solution and also backwards compatible.

FYI @dlfryar 